### PR TITLE
WebIDL will now correctly create `source/spasm` directory...

### DIFF
--- a/webidl/source/app.d
+++ b/webidl/source/app.d
@@ -77,7 +77,7 @@ void main(string[] args)
   if (generateBindings) {
     if (jsFolder == "")
       jsFolder = getcwd() ~ "/spasm/modules";
-    mkdir(jsFolder).ignoreExceptions;
+    mkdirRecurse(jsFolder).ignoreExceptions;
     dFolder = "";
     if (wasmFile == "")
       wasmFile = guessWasmFile();


### PR DESCRIPTION
…if it does not exist when running with `--bindgen`