### PR TITLE
Added a runtime stub for bsr.

### DIFF
--- a/source/spasm/rt/stubs.d
+++ b/source/spasm/rt/stubs.d
@@ -7,3 +7,10 @@ auto ternaryModuleConstructor(bool b, Ternary* t) {
   (cast(ubyte*)t)[0] = b << 1;
   return t;
 }
+
+version (LDC)
+pragma(mangle, "_D4core5bitop3bsrFNaNbNiNfkZi")
+pure int bsr(uint v) {
+    import ldc.intrinsics;
+    return cast(int) (typeof(v).sizeof * 8 - 1 - llvm_ctlz(v, true));
+}


### PR DESCRIPTION
LDC 1.18 for some reason did not link the mangled name otherwise.